### PR TITLE
added sims_utils to repos.yaml

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -3,6 +3,7 @@ lsst_thirdparty: https://github.com/lsst/lsst_thirdparty.git
 lsst_apps: https://github.com/lsst/lsst_apps.git
 twisted: https://github.com/lsst/twisted.git
 throughputs: git://git.lsstcorp.org/LSST/sims/throughputs.git
+sims_utils: https://stash.lsstcorp.org/scm/sim/sims_utils.git
 sims_catalogs_measures: https://stash.lsstcorp.org/scm/sim/sims_catalogs_measures.git
 scisql: https://github.com/lsst/scisql.git
 pex_logging: https://github.com/lsst/pex_logging.git


### PR DESCRIPTION
We have created a new stash repository sims_utils to contain simple utility functions used by the simulations stack.  I would like to add it to repos.yaml so that build bot knows about it.